### PR TITLE
Catch `OSError` when JSON string is passed to `Path`

### DIFF
--- a/action/__main__.py
+++ b/action/__main__.py
@@ -22,10 +22,13 @@ def convert_config(file_or_string: str) -> Dict:
 
     try:
         path_exists = path.exists()
-    except OSError:
-        # The name component of the path is too long for the file system. It's likely
-        # that `file_or_string` is a string, so we won't re-raise the error.
-        path_exists = False
+    except OSError as e:
+        if e.errno == 63:  # File name too long
+            # The name component of the path is too long for the file system. It's
+            # likely that `file_or_string` is a string, so we won't re-raise the error.
+            path_exists = False
+        else:
+            raise e
 
     try:
         if path_exists:

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+from unittest import mock
 
 import pytest
 
@@ -23,6 +24,12 @@ class TestConvertConfig:
         long_list_as_json = json.dumps(long_list)
         assert len(long_list_as_json) == 3 * n
         assert __main__.convert_config(long_list_as_json) == long_list
+
+    @mock.patch("action.__main__.Path.exists", side_effect=OSError())
+    def test_raises_oserror(self, mocked):
+        # Test that the function doesn't catch all instances of OSError.
+        with pytest.raises(OSError):
+            __main__.convert_config("config.json")
 
     def test_with_path_to_valid_json(self, tmp_path):
         path = tmp_path / "config.json"


### PR DESCRIPTION
Previously, we passed a variable that contained either a JSON string or a path to a JSON file to the `Path` constructor, using `my_path.exists` to determine whether we were handling the former or the latter. However, with long JSON strings (255 characters/bytes in most cases), this prompted `my_path.exists` to raise an `OSError` 💣.

We could rewrite the function to parse the variable as if it were a JSON string first and, if that failed, then open it as if it were a path to a JSON file second. However, we would need nested `try`/`except` blocks; if parsing the variable as if it were a JSON string failed because of bad JSON, rather than because it was a path to a JSON file, then we couldn't report this to the user. As someone who has been bitten by systems that write out bad JSON -- with single quotes rather than double quotes, for example -- I think this approach is sub-optimal. Hence catching `OSError` instead.

Closes #18