### PR TITLE
Integrate changes from `python-action-template`

### DIFF
--- a/action/__init__.py
+++ b/action/__init__.py
@@ -1,5 +1,6 @@
 import pathlib
 
+
 MODULE_ROOT = pathlib.Path(__file__).resolve().parent
 
 

--- a/action/find_save_tools.py
+++ b/action/find_save_tools.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from .errors import ImportActionError
 
+
 TableConfig = Dict[str, Union[str, Sequence[str]]]
 
 

--- a/action/utils.py
+++ b/action/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+
 DEFAULTS = {"output_path": "safetab_tables", "limit": 5}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,28 @@
+[tool.black]
+exclude = '''
+(
+  /(
+      \.git         # exclude a few common directories
+    | \.direnv
+    | \.venv
+    | venv
+  )/
+)
+'''
+
+[tool.coverage.run]
+branch = true
+omit = []
+
+[tool.coverage.report]
+skip_covered = true
+
+[tool.coverage.html]
+
 [tool.isort]
 profile = "black"
+lines_after_imports = 2
+skip_glob = [".direnv", "venv", ".venv"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=action tests"

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -13,3 +13,4 @@ flake8-implicit-str-concat
 isort
 mypy
 pytest
+pytest-cov

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -216,7 +216,9 @@ coverage==5.5 \
     --hash=sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079 \
     --hash=sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d \
     --hash=sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6
-    # via nbval
+    # via
+    #   nbval
+    #   pytest-cov
 cryptography==3.4.7 \
     --hash=sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d \
     --hash=sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959 \
@@ -674,6 +676,7 @@ kiwisolver==1.3.1 \
     --hash=sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31 \
     --hash=sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9 \
     --hash=sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0 \
+    --hash=sha256:24cc411232d14c8abafbd0dddb83e1a4f54d77770b53db72edcfe1d611b3bf11 \
     --hash=sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72 \
     --hash=sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3 \
     --hash=sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6 \
@@ -684,8 +687,10 @@ kiwisolver==1.3.1 \
     --hash=sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21 \
     --hash=sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621 \
     --hash=sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b \
+    --hash=sha256:6d9d8d9b31aa8c2d80a690693aebd8b5e2b7a45ab065bb78f1609995d2c79240 \
     --hash=sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc \
     --hash=sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131 \
+    --hash=sha256:792e69140828babe9649de583e1a03a0f2ff39918a71782c76b3c683a67c6dfd \
     --hash=sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882 \
     --hash=sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454 \
     --hash=sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248 \
@@ -700,6 +705,8 @@ kiwisolver==1.3.1 \
     --hash=sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689 \
     --hash=sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4 \
     --hash=sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0 \
+    --hash=sha256:d6563ccd46b645e966b400bb8a95d3457ca6cf3bba1e908f9e0927901dfebeb1 \
+    --hash=sha256:ef6eefcf3944e75508cdfa513c06cf80bafd7d179e14c1334ebdca9ebb8c2c66 \
     --hash=sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05 \
     --hash=sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9
     # via matplotlib
@@ -1349,6 +1356,11 @@ pytest==6.2.4 \
     #   -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
     #   -r requirements.dev.in
     #   nbval
+    #   pytest-cov
+pytest-cov==2.12.1 \
+    --hash=sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a \
+    --hash=sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7
+    # via -r requirements.dev.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
@@ -1732,6 +1744,7 @@ toml==0.10.2 \
     #   jupytext
     #   mypy
     #   pytest
+    #   pytest-cov
 tomli==1.2.1 \
     --hash=sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f \
     --hash=sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -6,6 +6,7 @@ import pytest
 
 from action import __main__
 
+
 VALID_JSON = '{"key": "value"}'
 VALID_JSON_AS_DICT = {"key": "value"}
 INVALID_JSON = "{'key': 'value'}"  # JSON doesn't like single quotes


### PR DESCRIPTION
These changes add support for pytest-cov as well as some additional configuration options for Black.

Upstream changes:
* https://github.com/opensafely-actions/python-action-template/pull/28
* https://github.com/opensafely-actions/python-action-template/pull/29

This PR is similar to https://github.com/opensafely-actions/cohort-report/pull/16.