### PR TITLE
Fix `test_prettify_tables`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 @pytest.fixture
 def crosstab():
     index = pd.Index(["M", "F"], name="sex")
-    columns = pd.Index([1, 0], name="copd")
+    columns = pd.Index([1, 0], name="has_copd")
     data = np.full((len(index), len(columns)), 6)
     return pd.DataFrame(data, index, columns)
 

--- a/tests/test_create_tables.py
+++ b/tests/test_create_tables.py
@@ -11,7 +11,7 @@ def test_prettify_tables(crosstab):
         variables=[crosstab.index.name, crosstab.columns.name],
     )
     assert isinstance(output_str, str)
-    assert output_str[:11] == "sex vs copd"
+    assert output_str.startswith("sex vs has_copd")
 
 
 class TestOutputTables:


### PR DESCRIPTION
Previously, we sliced to determine whether the output string started with the expected column name. Now, we call `startswith`.

Fixes #17