### PR TITLE
Refactor `output_tables`

### DIFF
--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -1,6 +1,6 @@
 import itertools
 import pathlib
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 
@@ -126,8 +126,7 @@ def output_tables(
     # all two element combinations of variables
     # data split by values of the groupby variable
 
-    two_way_tables: Dict = {}
-    targeted_two_way_tables: Dict = {}
+    two_way_and_target_two_way: Dict[str, List[Tuple]] = {}
     groupby_two_way_tables: Dict = {}
 
     for group_name, group_config in table_config.items():
@@ -137,14 +136,14 @@ def output_tables(
         table_groupby = group_config.get("groupby")
 
         if table_type == "2-way":
-            two_way_tables[group_name] = list(
+            two_way_and_target_two_way[group_name] = list(
                 itertools.combinations(table_variables, 2)
             )
 
         elif table_type == "target-2-way":
-            targeted_two_way_tables[group_name] = []
-            for var in table_variables:
-                targeted_two_way_tables[group_name].append([var, table_target])
+            two_way_and_target_two_way[group_name] = [
+                (x, table_target) for x in table_variables
+            ]
 
         elif table_type == "groupby-2-way":
             grouped_datasets = _split_groupby(df, table_groupby)
@@ -154,16 +153,7 @@ def output_tables(
                 "variable_pairs": variable_pairs,
             }
 
-    # Call function for each pair of variables for each named group of 2-way tables
-    for group_name, variable_pairs in two_way_tables.items():
-        for variable_pair in variable_pairs:
-            _output_simple_two_way(
-                df, group_name, variable_pair, output_dir=output_dir, limit=limit
-            )
-
-    # Call function for each pair of variables for each named group of target-2-way
-    # tables
-    for group_name, variable_pairs in targeted_two_way_tables.items():
+    for group_name, variable_pairs in two_way_and_target_two_way.items():
         for variable_pair in variable_pairs:
             _output_simple_two_way(
                 df, group_name, variable_pair, output_dir=output_dir, limit=limit

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -169,8 +169,8 @@ def output_tables(
                     group_name,
                     variable_pair,
                     output_dir=output_dir,
-                    additional_info=name,
                     limit=limit,
+                    additional_info=name,
                 )
 
 

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -113,7 +113,19 @@ def output_tables(
 
     make_output_dirs(table_config, output_dir)
 
-    # Sort the json into options
+    # For each item in the configuration dictionary, expand the variables as required by
+    # the type of table.
+    #
+    # 2-way:
+    # all two element combinations of variables
+    #
+    # target-2-way:
+    # two element combinations of each variable and the target variable
+    #
+    # groupby-2-way:
+    # all two element combinations of variables
+    # data split by values of the groupby variable
+
     two_way_tables: Dict = {}
     targeted_two_way_tables: Dict = {}
     groupby_two_way_tables: Dict = {}

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -130,25 +130,27 @@ def output_tables(
     targeted_two_way_tables: Dict = {}
     groupby_two_way_tables: Dict = {}
 
-    for name_tables, instructions in table_config.items():
-        if instructions["tab_type"] == "2-way":
-            two_way_tables[name_tables] = list(
-                itertools.combinations(instructions["variables"], 2)
+    for group_name, group_config in table_config.items():
+        table_type = group_config["tab_type"]
+        table_variables = group_config["variables"]
+        table_target = group_config.get("target")
+        table_groupby = group_config.get("groupby")
+
+        if table_type == "2-way":
+            two_way_tables[group_name] = list(
+                itertools.combinations(table_variables, 2)
             )
 
-        elif instructions["tab_type"] == "target-2-way":
-            targeted_two_way_tables[name_tables] = []
-            for var in instructions["variables"]:
-                targeted_two_way_tables[name_tables].append(
-                    [var, instructions["target"]]
-                )
+        elif table_type == "target-2-way":
+            targeted_two_way_tables[group_name] = []
+            for var in table_variables:
+                targeted_two_way_tables[group_name].append([var, table_target])
 
-        elif instructions["tab_type"] == "groupby-2-way":
-            data = _split_groupby(df, instructions["groupby"])
-            variable_pairs = list(itertools.combinations(instructions["variables"], 2))
-
-            groupby_two_way_tables[name_tables] = {
-                "grouped_datasets": data,
+        elif table_type == "groupby-2-way":
+            grouped_datasets = _split_groupby(df, table_groupby)
+            variable_pairs = list(itertools.combinations(table_variables, 2))
+            groupby_two_way_tables[group_name] = {
+                "grouped_datasets": grouped_datasets,
                 "variable_pairs": variable_pairs,
             }
 

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -1,6 +1,6 @@
 import itertools
 import pathlib
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 
@@ -131,7 +131,7 @@ def output_tables(
     # data split by values of the groupby variable
 
     two_way_and_target_two_way: Dict[str, List[Tuple]] = {}
-    groupby_two_way_tables: Dict = {}
+    groupby_two_way: Dict[str, Dict[str, Any]] = {}
 
     for group_name, group_config in table_config.items():
         table_type = group_config["tab_type"]
@@ -150,7 +150,7 @@ def output_tables(
         elif table_type == "groupby-2-way":
             grouped_datasets = _split_groupby(df, table_groupby)
             variable_pairs = _get_pairs(table_variables)
-            groupby_two_way_tables[group_name] = {
+            groupby_two_way[group_name] = {
                 "grouped_datasets": grouped_datasets,
                 "variable_pairs": variable_pairs,
             }
@@ -161,9 +161,7 @@ def output_tables(
                 df, group_name, variable_pair, output_dir=output_dir, limit=limit
             )
 
-    # Call function for each pair of variables for each grouped dataset for each named
-    # group of groupby-2-way tables
-    for group_name, group_data in groupby_two_way_tables.items():
+    for group_name, group_data in groupby_two_way.items():
         for name, dataset in group_data["grouped_datasets"].items():
             for variable_pair in group_data["variable_pairs"]:
                 _output_simple_two_way(

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -145,11 +145,11 @@ def output_tables(
 
         elif instructions["tab_type"] == "groupby-2-way":
             data = _split_groupby(df, instructions["groupby"])
-            permutations = list(itertools.combinations(instructions["variables"], 2))
+            variable_pairs = list(itertools.combinations(instructions["variables"], 2))
 
             groupby_two_way_tables[name_tables] = {
                 "grouped_datasets": data,
-                "permutations": permutations,
+                "variable_pairs": variable_pairs,
             }
 
     # Call function for each pair of variables for each named group of 2-way tables
@@ -167,17 +167,17 @@ def output_tables(
                 df, group_name, variable_pair, output_dir=output_dir, limit=limit
             )
 
-    # run through all the grouped 2 way tables
-    for folder_names, table_info in groupby_two_way_tables.items():
-
-        for dataset_name, dataset in table_info["grouped_datasets"].items():
-            for combination in table_info["permutations"]:
+    # Call function for each pair of variables for each grouped dataset for each named
+    # group of groupby-2-way tables
+    for group_name, group_data in groupby_two_way_tables.items():
+        for name, dataset in group_data["grouped_datasets"].items():
+            for variable_pair in group_data["variable_pairs"]:
                 _output_simple_two_way(
                     dataset,
-                    folder_names,
-                    combination,
+                    group_name,
+                    variable_pair,
                     output_dir=output_dir,
-                    additional_info=dataset_name,
+                    additional_info=name,
                     limit=limit,
                 )
 

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -83,6 +83,10 @@ def prettify_tables(table: pd.DataFrame, variables: list) -> str:
     return output_str
 
 
+def _get_pairs(it):
+    return list(itertools.combinations(it, 2))
+
+
 def output_tables(
     data_csv: str,
     table_config: Dict,
@@ -136,9 +140,7 @@ def output_tables(
         table_groupby = group_config.get("groupby")
 
         if table_type == "2-way":
-            two_way_and_target_two_way[group_name] = list(
-                itertools.combinations(table_variables, 2)
-            )
+            two_way_and_target_two_way[group_name] = _get_pairs(table_variables)
 
         elif table_type == "target-2-way":
             two_way_and_target_two_way[group_name] = [
@@ -147,7 +149,7 @@ def output_tables(
 
         elif table_type == "groupby-2-way":
             grouped_datasets = _split_groupby(df, table_groupby)
-            variable_pairs = list(itertools.combinations(table_variables, 2))
+            variable_pairs = _get_pairs(table_variables)
             groupby_two_way_tables[group_name] = {
                 "grouped_datasets": grouped_datasets,
                 "variable_pairs": variable_pairs,

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -159,13 +159,12 @@ def output_tables(
                 df, group_name, variable_pair, output_dir=output_dir, limit=limit
             )
 
-    # run through all the targeted 2 way tables
-    for name_tables, table_info in targeted_two_way_tables.items():
-
-        # run through create each table and log if table made
-        for table_instructions in targeted_two_way_tables[name_tables]:
+    # Call function for each pair of variables for each named group of target-2-way
+    # tables
+    for group_name, variable_pairs in targeted_two_way_tables.items():
+        for variable_pair in variable_pairs:
             _output_simple_two_way(
-                df, name_tables, table_instructions, output_dir=output_dir, limit=limit
+                df, group_name, variable_pair, output_dir=output_dir, limit=limit
             )
 
     # run through all the grouped 2 way tables

--- a/action/create_tables.py
+++ b/action/create_tables.py
@@ -152,13 +152,11 @@ def output_tables(
                 "permutations": permutations,
             }
 
-    # run through all two way tables
-    for name_tables, table_info in two_way_tables.items():
-
-        # run through create each table and log if table made
-        for table_instructions in two_way_tables[name_tables]:
+    # Call function for each pair of variables for each named group of 2-way tables
+    for group_name, variable_pairs in two_way_tables.items():
+        for variable_pair in variable_pairs:
             _output_simple_two_way(
-                df, name_tables, table_instructions, output_dir=output_dir, limit=limit
+                df, group_name, variable_pair, output_dir=output_dir, limit=limit
             )
 
     # run through all the targeted 2 way tables


### PR DESCRIPTION
Here, I've refactored two aspects of the `output_tables` function:

* **The table configuration transformation loop.** This is where we transform the table configuration into instructions for creating cross tabs. The table configuration is passed as the `table_config` argument; `tests.conftest.table_configs` contains an example. I've renamed variables for clarity and merged similar transformations. (The commit messages call this loop the *data wrangling* loop.)
* **The cross tabs loop.** This is where we loop over the instructions for creating cross tabs and create the cross tabs themselves. Again, I've renamed variables for clarity.

Running `tests.test_create_tables.TestOutputTables` on `main` and then on this branch should give you confidence that this refactoring is successful, although see #31 for a discussion of the limitations of this test.